### PR TITLE
Add PDF itinerary import to Trips tab

### DIFF
--- a/index.html
+++ b/index.html
@@ -222,6 +222,7 @@
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/2.14.305/pdf.min.js"></script>
   <script>
+    // Configure PDF.js worker so parsing runs without cross-origin issues
     pdfjsLib.GlobalWorkerOptions.workerSrc = "https://cdnjs.cloudflare.com/ajax/libs/pdf.js/2.14.305/pdf.worker.min.js";
     // ---------- State ----------
     const $ = (s, r=document)=>r.querySelector(s);

--- a/index.html
+++ b/index.html
@@ -222,6 +222,7 @@
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/2.14.305/pdf.min.js"></script>
   <script>
+    pdfjsLib.GlobalWorkerOptions.workerSrc = "https://cdnjs.cloudflare.com/ajax/libs/pdf.js/2.14.305/pdf.worker.min.js";
     // ---------- State ----------
     const $ = (s, r=document)=>r.querySelector(s);
     const $$ = (s, r=document)=>Array.from(r.querySelectorAll(s));

--- a/index.html
+++ b/index.html
@@ -62,7 +62,9 @@
     .thumbs img{width:100%;height:90px;object-fit:cover;border-radius:8px;border:1px solid var(--line)}
     details>summary{cursor:pointer;font-weight:600;margin:.5rem 0}
     .mono{font-family:ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,monospace}
-    .mapWrap iframe{border:0;width:100%;height:520px;border-radius:12px}
+    .mapWrap{position:relative;overflow:hidden;border-radius:12px}
+    .mapWrap iframe{border:0;width:100%;height:520px}
+    .mapWrap::after{content:"";position:absolute;top:0;left:0;width:100%;height:40px;background:var(--bg);pointer-events:none}
     .trip-preview{width:100%;border-collapse:collapse;margin-top:1rem}
     .trip-preview th,.trip-preview td{border:1px solid #ddd;padding:8px}
     .trip-preview th{background:#f4f4f4;text-align:left}

--- a/index.html
+++ b/index.html
@@ -131,16 +131,14 @@
         <!-- TRIPS -->
         <article id="trips" class="card" role="tabpanel" aria-labelledby="tab-trips" hidden>
           <h2>Trips</h2>
-          <p class="muted">Paste simple CSV: <span class="mono">date, place, activity</span>. Example: <span class="mono">2025-09-01, Athens, Anafiotika wander</span></p>
-          <textarea id="tripCsv" rows="6" placeholder="YYYY-MM-DD, Place, Activity"></textarea>
-          <div class="row" style="justify-content:flex-end">
-            <button id="loadTrips" class="btn primary">Load itinerary</button>
-          </div>
-          <div id="tripList" class="grid" style="margin-top:10px"></div>
-          <div class="import-pdf">
-            <button id="import-pdf-btn" class="btn">Import PDF Itinerary</button>
-            <input type="file" id="pdf-upload" accept="application/pdf" hidden />
-            <div id="pdf-preview" class="pdf-preview"></div>
+          <p class="muted">Import and preview your itineraries here.</p>
+          <div>
+            <button id="importPdfBtn" class="btn">Import PDF Itinerary</button>
+            <input type="file" id="pdfInput" accept="application/pdf" hidden />
+            <div id="pdfPreview" class="preview"></div>
+            <button id="saveTripBtn" class="btn">Save This Trip</button>
+            <h3>Saved Trips</h3>
+            <div id="savedTrips"></div>
           </div>
         </article>
 
@@ -176,22 +174,21 @@
     </main>
   </div>
 
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/2.14.305/pdf.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/2.16.105/pdf.min.js"></script>
   <script type="module">
     import React from "https://esm.sh/react@18";
     import { createRoot } from "https://esm.sh/react-dom@18/client";
     import LivingMatrix from "./src/components/LivingMatrix.jsx";
 
     // Configure PDF.js worker so parsing runs without cross-origin issues
-    pdfjsLib.GlobalWorkerOptions.workerSrc = "https://cdnjs.cloudflare.com/ajax/libs/pdf.js/2.14.305/pdf.worker.min.js";
+    pdfjsLib.GlobalWorkerOptions.workerSrc = "https://cdnjs.cloudflare.com/ajax/libs/pdf.js/2.16.105/pdf.worker.min.js";
     // ---------- State ----------
     const $ = (s, r=document)=>r.querySelector(s);
     const $$ = (s, r=document)=>Array.from(r.querySelectorAll(s));
     const state = {
       emm: { d:1, mu:1, s:1, tau:1, k:1 },
       entries: JSON.parse(localStorage.getItem('mjj.entries')||'[]'),
-      photos:  JSON.parse(localStorage.getItem('mjj.photos')||'[]'), // [{dataURL, date}]
-      trips:   JSON.parse(localStorage.getItem('mjj.trips')||'[]')   // [{date, place, activity}]
+      photos:  JSON.parse(localStorage.getItem('mjj.photos')||'[]') // [{dataURL, date}]
     };
 
     const matrixRoot = createRoot(document.getElementById('matrix-root'));
@@ -283,102 +280,72 @@
       a.click(); URL.revokeObjectURL(a.href);
     }
 
-    // ---------- Trips ----------
-    function loadTrips(){
-      const text = $('#tripCsv').value.trim();
-      if(!text){ $('#tripList').innerHTML='<p class="muted">Paste a few lines first.</p>'; return; }
-      const rows = text.split('\n').map(l=>l.split(',').map(s=>s.trim()));
-      const items = rows.filter(r=>r.length>=2).map(r=>({date:r[0], place:r[1], activity:r[2]||''}));
-      state.trips = items;
-      localStorage.setItem('mjj.trips', JSON.stringify(state.trips));
-      renderTrips();
-    }
-    function renderTrips(){
-      const box = $('#tripList');
-      if(state.trips.length===0){ box.innerHTML=''; return; }
-      box.innerHTML = state.trips.map(t=>`
-        <div class="row" style="justify-content:space-between;border-bottom:1px solid var(--line);padding:6px 0">
-          <div><strong>${t.date}</strong> — ${t.place}${t.activity?': '+t.activity:''}</div>
-          <div class="chips"><span class="chip">itinerary</span></div>
-        </div>
-      `).join('');
-    }
-
     // ---------- Trips PDF Import ----------
-    const importBtn = document.getElementById("import-pdf-btn");
-    const fileInput = document.getElementById("pdf-upload");
-    const previewDiv = document.getElementById("pdf-preview");
+    const importPdfBtn = document.getElementById("importPdfBtn");
+    const pdfInput = document.getElementById("pdfInput");
+    const pdfPreview = document.getElementById("pdfPreview");
+    const saveTripBtn = document.getElementById("saveTripBtn");
+    const savedTripsDiv = document.getElementById("savedTrips");
 
-    importBtn?.addEventListener("click", () => fileInput.click());
+    let currentTripRows = [];
 
-    fileInput?.addEventListener("change", async (e) => {
-      const file = e.target.files[0];
-      if (!file) return;
+    importPdfBtn.addEventListener("click", () => pdfInput.click());
+    pdfInput.addEventListener("change", handlePdf);
+    saveTripBtn.addEventListener("click", saveTrip);
 
-      const reader = new FileReader();
-      reader.onload = async function() {
-        const typedArray = new Uint8Array(this.result);
-
-        const pdf = await pdfjsLib.getDocument(typedArray).promise;
-        let textContent = "";
-
-        for (let i = 1; i <= pdf.numPages; i++) {
-          const page = await pdf.getPage(i);
-          const content = await page.getTextContent();
-          const strings = content.items.map(item => item.str);
-          textContent += strings.join(" ") + "\n";
-        }
-
-        renderPreview(textContent);
-      };
-      reader.readAsArrayBuffer(file);
-      e.target.value = ""; // allow re-selecting the same file later
-    });
-
-    function renderPreview(text) {
-      const lines = text.split(/\n+/).map(l => l.trim()).filter(Boolean);
-
-      let rows = [];
-      let currentDate = "";
-
-      lines.forEach(line => {
-        if (/^\d{1,2}\s+\w+\s+\d{4}/.test(line)) {
-          currentDate = line;
-        } else {
-          rows.push({ date: currentDate, detail: line });
-        }
-      });
-
-      previewDiv.innerHTML = `
-        <table class="trip-preview">
-          <thead><tr><th>Date</th><th>Detail</th></tr></thead>
-          <tbody>
-            ${rows.map(r => `<tr><td>${r.date}</td><td>${r.detail}</td></tr>`).join("")}
-          </tbody>
-        </table>
-        <button id="save-trips-btn" class="btn">Save to Trips</button>
-      `;
-
-      document.getElementById("save-trips-btn").onclick = () => {
-        state.trips = rows.map(r => ({ date: r.date, place: r.detail, activity: '' }));
-        localStorage.setItem('mjj.trips', JSON.stringify(state.trips));
-        renderTrips();
-        renderPreviewRows(rows);
-        alert("Trips saved!");
-      };
+    async function handlePdf(evt){
+      const file = evt.target.files[0];
+      if(!file) return;
+      const arrayBuffer = await file.arrayBuffer();
+      const pdf = await pdfjsLib.getDocument({data: arrayBuffer}).promise;
+      let text = "";
+      for(let i=1;i<=pdf.numPages;i++){
+        const page = await pdf.getPage(i);
+        const content = await page.getTextContent();
+        text += content.items.map(it=>it.str).join(" ") + "\n";
+      }
+      renderPreview(text);
+      evt.target.value = ""; // allow re-selecting same file
     }
 
-    function renderPreviewRows(rows){
-      if(!rows || rows.length===0){ previewDiv.innerHTML=''; return; }
-      previewDiv.innerHTML = `
-        <table class="trip-preview">
-          <thead><tr><th>Date</th><th>Detail</th></tr></thead>
+    function renderPreview(text){
+      const lines = text.split(/\n+/).map(l=>l.trim()).filter(Boolean);
+      currentTripRows = lines.map((line,i)=>({id:i, raw:line}));
+      const table = `
+        <table>
+          <thead><tr><th>#</th><th>Detail</th></tr></thead>
           <tbody>
-            ${rows.map(r => `<tr><td>${r.date}</td><td>${r.detail}</td></tr>`).join("")}
+            ${currentTripRows.map(r=>`<tr><td>${r.id+1}</td><td>${r.raw}</td></tr>`).join("")}
           </tbody>
         </table>
       `;
+      pdfPreview.innerHTML = table;
     }
+
+    function saveTrip(){
+      if(!currentTripRows.length) return alert("No trip to save!");
+      const saved = JSON.parse(localStorage.getItem("myTrips")||"[]");
+      const trip = { id: Date.now(), rows: currentTripRows };
+      saved.push(trip);
+      localStorage.setItem("myTrips", JSON.stringify(saved));
+      renderSavedTrips();
+    }
+
+    function renderSavedTrips(){
+      const saved = JSON.parse(localStorage.getItem("myTrips")||"[]");
+      if(!saved.length){
+        savedTripsDiv.innerHTML = "<em>No saved trips</em>";
+        return;
+      }
+      savedTripsDiv.innerHTML = saved.map(t=>`
+        <details>
+          <summary>Trip ${new Date(t.id).toLocaleString()}</summary>
+          <ul>${t.rows.map(r=>`<li>${r.raw}</li>`).join("")}</ul>
+        </details>
+      `).join("");
+    }
+
+    // Restore saved trips on load handled during init
 
     // ---------- Gallery ----------
     function handlePhotos(ev){
@@ -433,12 +400,10 @@
     applyEMM(state.emm);
     renderMatrix();
     wireInnerCompass(); wireTabs();
-    renderRecent(); renderTrips(); renderThumbs();
-    renderPreviewRows(state.trips.map(t=>({date:t.date, detail:t.place + (t.activity?': '+t.activity:'')})));
+    renderRecent(); renderSavedTrips(); renderThumbs();
 
     $('#saveEntry').addEventListener('click', saveEntry);
     $('#exportJournal').addEventListener('click', exportJournal);
-    $('#loadTrips').addEventListener('click', loadTrips);
     $('#photos').addEventListener('change', handlePhotos);
     $('#copyLink').addEventListener('click', copyShare);
   </script>

--- a/index.html
+++ b/index.html
@@ -36,24 +36,20 @@
     nav.tabs a[aria-current="page"]{background:var(--blue);border-color:var(--blue);color:#fff}
 
     /* Matrix SVG animation — “thinks quietly in the background” */
-    .matrix{width:100%;height:auto;display:block}
-    .outer{transform-origin:50% 50%;animation:breathe calc(6s / var(--tau)) ease-in-out infinite alternate}
-    .petals-cw{transform-origin:50% 50%;animation:spinCW calc(40s / var(--s)) linear infinite}
-    .petals-ccw{transform-origin:50% 50%;animation:spinCCW calc(36s / var(--s)) linear infinite}
-    .orbit-fast{transform-origin:50% 50%;animation:spinCW calc(18s / var(--s)) linear infinite}
-    .orbit-medium{transform-origin:50% 50%;animation:spinCW calc(24s / var(--s)) linear infinite}
-    .orbit-slow{transform-origin:50% 50%;animation:spinCW calc(30s / var(--s)) linear infinite}
-    .core{transform-origin:50% 50%;animation:pulse calc(2.8s / var(--k)) ease-in-out infinite alternate}
-    .traveller{filter:drop-shadow(0 0 calc(1.5px * var(--mu)) rgba(50,111,183,calc(.25 * var(--mu))))}
-
-    @keyframes breathe{from{transform:scale(calc(.98 * var(--d)))} to{transform:scale(calc(1.02 * var(--d)))}}
-    @keyframes spinCW{to{transform:rotate(360deg)}}
-    @keyframes spinCCW{to{transform:rotate(-360deg)}}
-    @keyframes pulse{from{transform:scale(calc(1 + (var(--k) - 1) * .25))} to{transform:scale(calc(1.08 + (var(--k)-1) * .35))}}
+    .matrix-container{display:flex;justify-content:center;margin:1rem 0}
+    .matrix-svg{width:100%;max-width:400px;height:auto}
+    #outer-field{transform-origin:200px 200px;animation:breathe calc(6s / var(--tau)) ease-in-out infinite alternate}
+    #petals{transform-origin:200px 200px;animation:rotate calc(20s / var(--s)) linear infinite}
+    #orbit-fast{transform-origin:200px 200px;animation:rotate calc(10s / var(--d)) linear infinite}
+    #orbit-slow{transform-origin:200px 200px;animation:rotate calc(15s / var(--mu)) linear infinite reverse}
+    #core{transform-origin:200px 200px;animation:pulse calc(2s / var(--k)) ease-in-out infinite alternate}
+    @keyframes breathe{from{transform:scale(0.95);} to{transform:scale(1.05);}}
+    @keyframes rotate{to{transform:rotate(360deg);}}
+    @keyframes pulse{from{transform:scale(0.9);} to{transform:scale(1.1);}}
 
     /* Respect OS reduced motion */
     @media (prefers-reduced-motion: reduce){
-      .outer,.petals-cw,.petals-ccw,.orbit-fast,.orbit-medium,.orbit-slow,.core{animation:none !important}
+      #outer-field,#petals,#orbit-fast,#orbit-slow,#core{animation:none !important}
     }
 
     /* Small helpers */
@@ -96,69 +92,59 @@
       <a href="#map"     id="tab-map"     role="tab" aria-controls="map">Map</a>
     </nav>
 
-    <main class="grid grid-2">
-      <!-- Left: Matrix -->
-      <section class="card">
-        <h2>Living Matrix</h2>
-        <p class="muted">Your inner compass rendered as living geometry. Adjusted quietly by your reflections.</p>
-        <svg id="matrix" class="matrix" viewBox="0 0 600 600" aria-label="Travel Matrix" style="--d:1;--mu:1;--s:1;--tau:1;--k:1">
-          <!-- outer field -->
-          <g class="outer">
-            <circle cx="300" cy="300" r="280" fill="none" stroke="#326FB7" stroke-width="1.2"/>
-          </g>
-          <!-- petals -->
-          <g class="petals-cw" opacity=".85">
-            <!-- six rings -->
-            <g transform="rotate(0 300 300)"><circle cx="300" cy="300" r="210" fill="none" stroke="#aeb4b9" stroke-width="1.2"/></g>
-            <g transform="rotate(30 300 300)"><circle cx="300" cy="300" r="210" fill="none" stroke="#aeb4b9" stroke-width="1.2"/></g>
-            <g transform="rotate(60 300 300)"><circle cx="300" cy="300" r="210" fill="none" stroke="#aeb4b9" stroke-width="1.2"/></g>
-            <g transform="rotate(90 300 300)"><circle cx="300" cy="300" r="210" fill="none" stroke="#aeb4b9" stroke-width="1.2"/></g>
-            <g transform="rotate(120 300 300)"><circle cx="300" cy="300" r="210" fill="none" stroke="#aeb4b9" stroke-width="1.2"/></g>
-            <g transform="rotate(150 300 300)"><circle cx="300" cy="300" r="210" fill="none" stroke="#aeb4b9" stroke-width="1.2"/></g>
-          </g>
-          <g class="petals-ccw" opacity=".65">
-            <g transform="rotate(15 300 300)"><circle cx="300" cy="300" r="170" fill="none" stroke="#326FB7" stroke-width="1.2"/></g>
-            <g transform="rotate(45 300 300)"><circle cx="300" cy="300" r="170" fill="none" stroke="#326FB7" stroke-width="1.2"/></g>
-            <g transform="rotate(75 300 300)"><circle cx="300" cy="300" r="170" fill="none" stroke="#326FB7" stroke-width="1.2"/></g>
-          </g>
-          <!-- orbits -->
-          <g class="orbit-fast">
-            <ellipse cx="300" cy="300" rx="250" ry="150" fill="none" stroke="#111" stroke-width="3" opacity=".9"/>
-            <circle cx="550" cy="300" r="10" fill="#111" class="traveller"/>
-          </g>
-          <g class="orbit-medium">
-            <ellipse cx="300" cy="300" rx="230" ry="210" fill="none" stroke="#aeb4b9" stroke-width="2.2"/>
-            <circle cx="70"  cy="300" r="10" fill="#111" class="traveller"/>
-          </g>
-          <g class="orbit-slow">
-            <ellipse cx="300" cy="300" rx="120" ry="260" fill="none" stroke="#111" stroke-width="2.2"/>
-            <circle cx="420" cy="300" r="10" fill="#111" class="traveller"/>
-          </g>
-          <!-- core -->
-          <g class="core">
-            <circle cx="300" cy="300" r="50" fill="#222" opacity=".88"/>
-            <circle cx="300" cy="300" r="70" fill="none" stroke="#326FB7" stroke-width="2.2" opacity=".95"/>
-          </g>
-        </svg>
-
-        <details>
-          <summary>Inner Compass (advanced)</summary>
-          <div class="grid" style="grid-template-columns:repeat(5,1fr);gap:10px;margin-top:8px">
-            <label class="mono">d <input id="d"   type="range" min="0.7" max="1.6" step="0.01"></label>
-            <label class="mono">μ <input id="mu"  type="range" min="0.5" max="2.0" step="0.01"></label>
-            <label class="mono">s <input id="s"   type="range" min="0.5" max="2.0" step="0.01"></label>
-            <label class="mono">τ <input id="tau" type="range" min="0.6" max="1.6" step="0.01"></label>
-            <label class="mono">k <input id="k"   type="range" min="0.8" max="1.6" step="0.01"></label>
-          </div>
-        </details>
-      </section>
-
-      <!-- Right: Journal / Trips / Gallery panels -->
+    <main>
       <section class="grid" id="panels">
         <!-- TODAY -->
         <article id="today" class="card" role="tabpanel" aria-labelledby="tab-today">
           <h2>Today</h2>
           <p class="muted">Two silent minutes. Say what mattered. The Matrix will listen.</p>
+
+          <div class="matrix-container">
+            <svg id="matrix-svg" viewBox="0 0 400 400" class="matrix-svg">
+              <!-- Background -->
+              <rect width="400" height="400" fill="#f8fafc" />
+
+              <!-- Outer breathing field -->
+              <g id="outer-field">
+                <circle cx="200" cy="200" r="180" fill="none" stroke="#326FB7" stroke-width="2" opacity="0.8"/>
+              </g>
+
+              <!-- Rotating petals -->
+              <g id="petals" opacity="0.6">
+                <circle cx="200" cy="200" r="120" fill="none" stroke="#aeb4b9" stroke-width="1.5"/>
+                <circle cx="200" cy="200" r="100" fill="none" stroke="#aeb4b9" stroke-width="1.5"/>
+              </g>
+
+              <!-- Orbits with travellers -->
+              <g id="orbit-fast">
+                <ellipse cx="200" cy="200" rx="160" ry="100" fill="none" stroke="#111" stroke-width="2.5"/>
+                <circle id="traveller-fast" cx="360" cy="200" r="6" fill="#111"/>
+              </g>
+
+              <g id="orbit-slow">
+                <ellipse cx="200" cy="200" rx="80" ry="140" fill="none" stroke="#666" stroke-width="2"/>
+                <circle id="traveller-slow" cx="280" cy="200" r="5" fill="#666"/>
+              </g>
+
+              <!-- Pulsing core -->
+              <g id="core">
+                <circle cx="200" cy="200" r="30" fill="#222" opacity="0.85"/>
+                <circle cx="200" cy="200" r="45" fill="none" stroke="#326FB7" stroke-width="2" opacity="0.9"/>
+              </g>
+            </svg>
+          </div>
+
+          <details>
+            <summary>Inner Compass (advanced)</summary>
+            <div class="grid" style="grid-template-columns:repeat(5,1fr);gap:10px;margin-top:8px">
+              <label class="mono">d <input id="d"   type="range" min="0.7" max="1.6" step="0.01"></label>
+              <label class="mono">μ <input id="mu"  type="range" min="0.5" max="2.0" step="0.01"></label>
+              <label class="mono">s <input id="s"   type="range" min="0.5" max="2.0" step="0.01"></label>
+              <label class="mono">τ <input id="tau" type="range" min="0.6" max="1.6" step="0.01"></label>
+              <label class="mono">k <input id="k"   type="range" min="0.8" max="1.6" step="0.01"></label>
+            </div>
+          </details>
+
           <div class="grid">
             <input id="title" type="text" placeholder="Title (e.g. Morning reflection)">
             <input id="tags"  type="text" placeholder="Tags (comma separated): calm, curious, connected">

--- a/index.html
+++ b/index.html
@@ -40,12 +40,13 @@
     .matrix-svg{width:100%;max-width:400px;height:auto}
     #outer-field{transform-origin:200px 200px;animation:breathe calc(6s / var(--tau)) ease-in-out infinite alternate}
     #petals{transform-origin:200px 200px;animation:rotate calc(20s / var(--s)) linear infinite}
-    #orbit-fast{transform-origin:200px 200px;animation:rotate calc(10s / var(--d)) linear infinite}
-    #orbit-slow{transform-origin:200px 200px;animation:rotate calc(15s / var(--mu)) linear infinite reverse}
-    #core{transform-origin:200px 200px;animation:pulse calc(2s / var(--k)) ease-in-out infinite alternate}
-    @keyframes breathe{from{transform:scale(0.95);} to{transform:scale(1.05);}}
+    #orbit-fast{transform-origin:200px 200px;animation:rotate calc(10s / var(--s)) linear infinite}
+    #orbit-slow{transform-origin:200px 200px;animation:rotate calc(15s / var(--s)) linear infinite reverse}
+    #traveller-fast,#traveller-slow{filter:drop-shadow(0 0 calc(4px * var(--mu)) #326FB7);}
+    #core{transform-origin:200px 200px;animation:pulse 2s ease-in-out infinite alternate}
+    @keyframes breathe{from{transform:scale(calc(0.95 * var(--d)));} to{transform:scale(calc(1.05 * var(--d)));}}
     @keyframes rotate{to{transform:rotate(360deg);}}
-    @keyframes pulse{from{transform:scale(0.9);} to{transform:scale(1.1);}}
+    @keyframes pulse{from{transform:scale(calc(0.9 * var(--k)));} to{transform:scale(calc(1.1 * var(--k)));}}
 
     /* Respect OS reduced motion */
     @media (prefers-reduced-motion: reduce){
@@ -101,40 +102,7 @@
           <h2>Today</h2>
           <p class="muted">Two silent minutes. Say what mattered. The Matrix will listen.</p>
 
-          <div class="matrix-container">
-            <svg id="matrix-svg" viewBox="0 0 400 400" class="matrix-svg">
-              <!-- Background -->
-              <rect width="400" height="400" fill="#f8fafc" />
-
-              <!-- Outer breathing field -->
-              <g id="outer-field">
-                <circle cx="200" cy="200" r="180" fill="none" stroke="#326FB7" stroke-width="2" opacity="0.8"/>
-              </g>
-
-              <!-- Rotating petals -->
-              <g id="petals" opacity="0.6">
-                <circle cx="200" cy="200" r="120" fill="none" stroke="#aeb4b9" stroke-width="1.5"/>
-                <circle cx="200" cy="200" r="100" fill="none" stroke="#aeb4b9" stroke-width="1.5"/>
-              </g>
-
-              <!-- Orbits with travellers -->
-              <g id="orbit-fast">
-                <ellipse cx="200" cy="200" rx="160" ry="100" fill="none" stroke="#111" stroke-width="2.5"/>
-                <circle id="traveller-fast" cx="360" cy="200" r="6" fill="#111"/>
-              </g>
-
-              <g id="orbit-slow">
-                <ellipse cx="200" cy="200" rx="80" ry="140" fill="none" stroke="#666" stroke-width="2"/>
-                <circle id="traveller-slow" cx="280" cy="200" r="5" fill="#666"/>
-              </g>
-
-              <!-- Pulsing core -->
-              <g id="core">
-                <circle cx="200" cy="200" r="30" fill="#222" opacity="0.85"/>
-                <circle cx="200" cy="200" r="45" fill="none" stroke="#326FB7" stroke-width="2" opacity="0.9"/>
-              </g>
-            </svg>
-          </div>
+          <div class="matrix-container"><div id="matrix-root"></div></div>
 
           <details>
             <summary>Inner Compass (advanced)</summary>
@@ -209,7 +177,11 @@
   </div>
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/2.14.305/pdf.min.js"></script>
-  <script>
+  <script type="module">
+    import React from "https://esm.sh/react@18";
+    import { createRoot } from "https://esm.sh/react-dom@18/client";
+    import LivingMatrix from "./src/components/LivingMatrix.jsx";
+
     // Configure PDF.js worker so parsing runs without cross-origin issues
     pdfjsLib.GlobalWorkerOptions.workerSrc = "https://cdnjs.cloudflare.com/ajax/libs/pdf.js/2.14.305/pdf.worker.min.js";
     // ---------- State ----------
@@ -221,6 +193,11 @@
       photos:  JSON.parse(localStorage.getItem('mjj.photos')||'[]'), // [{dataURL, date}]
       trips:   JSON.parse(localStorage.getItem('mjj.trips')||'[]')   // [{date, place, activity}]
     };
+
+    const matrixRoot = createRoot(document.getElementById('matrix-root'));
+    function renderMatrix(){
+      matrixRoot.render(<LivingMatrix {...state.emm} />);
+    }
 
     // ---------- EMM helpers ----------
     function parseParams(){
@@ -254,6 +231,7 @@
         input.addEventListener('input', ()=>{
           const next = {...state.emm, [k]: parseFloat(input.value)};
           applyEMM(next);
+          renderMatrix();
           history.replaceState(null,'', location.pathname + '?' + new URLSearchParams(next).toString());
         });
       });
@@ -268,6 +246,7 @@
 
       const emmFromTags = tags.length ? tagsToEMM(tags, state.emm) : state.emm;
       applyEMM(emmFromTags);
+      renderMatrix();
 
       const entry = {
         id: Date.now(),
@@ -452,6 +431,7 @@
     // ---------- Init ----------
     parseParams();
     applyEMM(state.emm);
+    renderMatrix();
     wireInnerCompass(); wireTabs();
     renderRecent(); renderTrips(); renderThumbs();
     renderPreviewRows(state.trips.map(t=>({date:t.date, detail:t.place + (t.activity?': '+t.activity:'')})));

--- a/index.html
+++ b/index.html
@@ -392,26 +392,25 @@
       `;
 
       document.getElementById("save-trips-btn").onclick = () => {
-        localStorage.setItem("myTrips", JSON.stringify(rows));
+        state.trips = rows.map(r => ({ date: r.date, place: r.detail, activity: '' }));
+        localStorage.setItem('mjj.trips', JSON.stringify(state.trips));
+        renderTrips();
+        renderPreviewRows(rows);
         alert("Trips saved!");
       };
     }
 
-    window.addEventListener("DOMContentLoaded", () => {
-      const saved = localStorage.getItem("myTrips");
-      if (saved) {
-        const rows = JSON.parse(saved);
-        previewDiv.innerHTML = `
-          <h4>Saved Trips</h4>
-          <table class="trip-preview">
-            <thead><tr><th>Date</th><th>Detail</th></tr></thead>
-            <tbody>
-              ${rows.map(r => `<tr><td>${r.date}</td><td>${r.detail}</td></tr>`).join("")}
-            </tbody>
-          </table>
-        `;
-      }
-    });
+    function renderPreviewRows(rows){
+      if(!rows || rows.length===0){ previewDiv.innerHTML=''; return; }
+      previewDiv.innerHTML = `
+        <table class="trip-preview">
+          <thead><tr><th>Date</th><th>Detail</th></tr></thead>
+          <tbody>
+            ${rows.map(r => `<tr><td>${r.date}</td><td>${r.detail}</td></tr>`).join("")}
+          </tbody>
+        </table>
+      `;
+    }
 
     // ---------- Gallery ----------
     function handlePhotos(ev){
@@ -466,6 +465,7 @@
     applyEMM(state.emm);
     wireInnerCompass(); wireTabs();
     renderRecent(); renderTrips(); renderThumbs();
+    renderPreviewRows(state.trips.map(t=>({date:t.date, detail:t.place + (t.activity?': '+t.activity:'')})));
 
     $('#saveEntry').addEventListener('click', saveEntry);
     $('#exportJournal').addEventListener('click', exportJournal);

--- a/index.html
+++ b/index.html
@@ -66,6 +66,9 @@
     .thumbs img{width:100%;height:90px;object-fit:cover;border-radius:8px;border:1px solid var(--line)}
     details>summary{cursor:pointer;font-weight:600;margin:.5rem 0}
     .mono{font-family:ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,monospace}
+    .trip-preview{width:100%;border-collapse:collapse;margin-top:1rem}
+    .trip-preview th,.trip-preview td{border:1px solid #ddd;padding:8px}
+    .trip-preview th{background:#f4f4f4;text-align:left}
   </style>
 </head>
 <body>
@@ -89,6 +92,7 @@
       <a href="#today"   id="tab-today"   role="tab" aria-controls="today"   aria-current="page">Today</a>
       <a href="#trips"   id="tab-trips"   role="tab" aria-controls="trips">Trips</a>
       <a href="#gallery" id="tab-gallery" role="tab" aria-controls="gallery">Gallery</a>
+      <a href="#map"     id="tab-map"     role="tab" aria-controls="map">Map</a>
     </nav>
 
     <main class="grid grid-2">
@@ -176,6 +180,11 @@
             <button id="loadTrips" class="btn primary">Load itinerary</button>
           </div>
           <div id="tripList" class="grid" style="margin-top:10px"></div>
+          <div class="import-pdf">
+            <button id="import-pdf-btn" class="btn">Import PDF Itinerary</button>
+            <input type="file" id="pdf-upload" accept="application/pdf" hidden />
+            <div id="pdf-preview" class="pdf-preview"></div>
+          </div>
         </article>
 
         <!-- GALLERY -->
@@ -185,10 +194,33 @@
           <input id="photos" type="file" accept="image/*" multiple />
           <div class="thumbs" id="thumbs" style="margin-top:10px"></div>
         </article>
+
+        <!-- MAP -->
+        <article id="map" class="card" role="tabpanel" aria-labelledby="tab-map" hidden>
+          <h2>Map</h2>
+          <p class="muted">Your CoTravel map. Edit it in Google My Maps; updates appear here automatically.</p>
+          <div class="mapWrap">
+            <iframe
+              id="mymap"
+              src="https://www.google.com/maps/d/embed?mid=1eFv5t__eYzlJHbm07FWcHc2zl4nxg4Y"
+              loading="lazy"
+              style="border:0;width:100%;height:520px;border-radius:12px"
+              referrerpolicy="no-referrer-when-downgrade"
+              aria-label="CoTravel Map">
+            </iframe>
+          </div>
+          <div class="row" style="margin-top:.5rem">
+            <a class="btn" target="_blank" rel="noopener"
+               href="https://www.google.com/maps/d/u/0/edit?mid=1eFv5t__eYzlJHbm07FWcHc2zl4nxg4Y&usp=sharing">
+              Open in My Maps (edit)
+            </a>
+          </div>
+        </article>
       </section>
     </main>
   </div>
 
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/2.14.305/pdf.min.js"></script>
   <script>
     // ---------- State ----------
     const $ = (s, r=document)=>r.querySelector(s);
@@ -303,6 +335,82 @@
       `).join('');
     }
 
+    // ---------- Trips PDF Import ----------
+    const importBtn = document.getElementById("import-pdf-btn");
+    const fileInput = document.getElementById("pdf-upload");
+    const previewDiv = document.getElementById("pdf-preview");
+
+    importBtn?.addEventListener("click", () => fileInput.click());
+
+    fileInput?.addEventListener("change", async (e) => {
+      const file = e.target.files[0];
+      if (!file) return;
+
+      const reader = new FileReader();
+      reader.onload = async function() {
+        const typedArray = new Uint8Array(this.result);
+
+        const pdf = await pdfjsLib.getDocument(typedArray).promise;
+        let textContent = "";
+
+        for (let i = 1; i <= pdf.numPages; i++) {
+          const page = await pdf.getPage(i);
+          const content = await page.getTextContent();
+          const strings = content.items.map(item => item.str);
+          textContent += strings.join(" ") + "\n";
+        }
+
+        renderPreview(textContent);
+      };
+      reader.readAsArrayBuffer(file);
+    });
+
+    function renderPreview(text) {
+      const lines = text.split(/\n+/).map(l => l.trim()).filter(Boolean);
+
+      let rows = [];
+      let currentDate = "";
+
+      lines.forEach(line => {
+        if (/^\d{1,2}\s+\w+\s+\d{4}/.test(line)) {
+          currentDate = line;
+        } else {
+          rows.push({ date: currentDate, detail: line });
+        }
+      });
+
+      previewDiv.innerHTML = `
+        <table class="trip-preview">
+          <thead><tr><th>Date</th><th>Detail</th></tr></thead>
+          <tbody>
+            ${rows.map(r => `<tr><td>${r.date}</td><td>${r.detail}</td></tr>`).join("")}
+          </tbody>
+        </table>
+        <button id="save-trips-btn" class="btn">Save to Trips</button>
+      `;
+
+      document.getElementById("save-trips-btn").onclick = () => {
+        localStorage.setItem("myTrips", JSON.stringify(rows));
+        alert("Trips saved!");
+      };
+    }
+
+    window.addEventListener("DOMContentLoaded", () => {
+      const saved = localStorage.getItem("myTrips");
+      if (saved) {
+        const rows = JSON.parse(saved);
+        previewDiv.innerHTML = `
+          <h4>Saved Trips</h4>
+          <table class="trip-preview">
+            <thead><tr><th>Date</th><th>Detail</th></tr></thead>
+            <tbody>
+              ${rows.map(r => `<tr><td>${r.date}</td><td>${r.detail}</td></tr>`).join("")}
+            </tbody>
+          </table>
+        `;
+      }
+    });
+
     // ---------- Gallery ----------
     function handlePhotos(ev){
       const files = Array.from(ev.target.files||[]);
@@ -327,20 +435,22 @@
 
     // ---------- Tabs ----------
     function wireTabs(){
-      const tabs = [['today','#tab-today'],['trips','#tab-trips'],['gallery','#tab-gallery']];
-      tabs.forEach(([id,btn])=>{
-        $(btn).addEventListener('click', e=>{
-          e.preventDefault();
-          tabs.forEach(([tid,tbtn])=>{
-            $('#'+tid).hidden = (tid!==id);
-            $(tbtn).setAttribute('aria-current', tid===id ? 'page' : 'false');
-          });
-          history.replaceState(null,'', location.pathname + location.search + '#'+id);
+      const KNOWN = ['#today', '#trips', '#gallery', '#map'];
+
+      function showPanel(hash){
+        const target = KNOWN.includes(hash) ? hash : '#today';
+        document.querySelectorAll('article[role="tabpanel"]').forEach(p => p.hidden = true);
+        const panel = document.querySelector(target);
+        if (panel) panel.hidden = false;
+        document.querySelectorAll('nav.tabs a[role="tab"]').forEach(a => {
+          const active = a.getAttribute('href') === target;
+          a.classList.toggle('active', active);
+          a.setAttribute('aria-current', active ? 'page' : 'false');
         });
-      });
-      // open deep link
-      const hash = location.hash.replace('#','');
-      if(['today','trips','gallery'].includes(hash)) $( '#tab-'+hash ).click();
+      }
+
+      window.addEventListener('hashchange', () => showPanel(location.hash));
+      showPanel(location.hash || '#today');
     }
 
     // ---------- Share link ----------

--- a/index.html
+++ b/index.html
@@ -66,6 +66,7 @@
     .thumbs img{width:100%;height:90px;object-fit:cover;border-radius:8px;border:1px solid var(--line)}
     details>summary{cursor:pointer;font-weight:600;margin:.5rem 0}
     .mono{font-family:ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,monospace}
+    .mapWrap iframe{border:0;width:100%;height:520px;border-radius:12px}
     .trip-preview{width:100%;border-collapse:collapse;margin-top:1rem}
     .trip-preview th,.trip-preview td{border:1px solid #ddd;padding:8px}
     .trip-preview th{background:#f4f4f4;text-align:left}
@@ -204,7 +205,6 @@
               id="mymap"
               src="https://www.google.com/maps/d/embed?mid=1eFv5t__eYzlJHbm07FWcHc2zl4nxg4Y"
               loading="lazy"
-              style="border:0;width:100%;height:520px;border-radius:12px"
               referrerpolicy="no-referrer-when-downgrade"
               aria-label="CoTravel Map">
             </iframe>
@@ -437,7 +437,7 @@
 
     // ---------- Tabs ----------
     function wireTabs(){
-      const KNOWN = ['#today', '#trips', '#gallery', '#map'];
+      const KNOWN = ['#today', '#trips', '#gallery', '#map']; // include #map for My Maps embed
 
       function showPanel(hash){
         const target = KNOWN.includes(hash) ? hash : '#today';

--- a/index.html
+++ b/index.html
@@ -365,6 +365,7 @@
         renderPreview(textContent);
       };
       reader.readAsArrayBuffer(file);
+      e.target.value = ""; // allow re-selecting the same file later
     });
 
     function renderPreview(text) {

--- a/index.html
+++ b/index.html
@@ -195,8 +195,8 @@
     };
 
     const matrixRoot = createRoot(document.getElementById('matrix-root'));
-    function renderMatrix(){
-      matrixRoot.render(<LivingMatrix {...state.emm} />);
+    function renderMatrix() {
+      matrixRoot.render(React.createElement(LivingMatrix, { ...state.emm }));
     }
 
     // ---------- EMM helpers ----------

--- a/src/components/LivingMatrix.jsx
+++ b/src/components/LivingMatrix.jsx
@@ -1,0 +1,35 @@
+import React from "https://esm.sh/react@18";
+
+export default function LivingMatrix({ d = 1, mu = 1, s = 1, tau = 1, k = 1 }) {
+  const style = {
+    '--d': d,
+    '--mu': mu,
+    '--s': s,
+    '--tau': tau,
+    '--k': k,
+  };
+  return (
+    <svg viewBox="0 0 400 400" className="matrix-svg" style={style}>
+      <rect width="400" height="400" fill="#f8fafc" />
+      <g id="outer-field">
+        <circle cx="200" cy="200" r="180" fill="none" stroke="#326FB7" strokeWidth="2" opacity="0.8" />
+      </g>
+      <g id="petals" opacity="0.6">
+        <circle cx="200" cy="200" r="120" fill="none" stroke="#aeb4b9" strokeWidth="1.5" />
+        <circle cx="200" cy="200" r="100" fill="none" stroke="#aeb4b9" strokeWidth="1.5" />
+      </g>
+      <g id="orbit-fast">
+        <ellipse cx="200" cy="200" rx="160" ry="100" fill="none" stroke="#111" strokeWidth="2.5" />
+        <circle id="traveller-fast" cx="360" cy="200" r="6" fill="#111" />
+      </g>
+      <g id="orbit-slow">
+        <ellipse cx="200" cy="200" rx="80" ry="140" fill="none" stroke="#666" strokeWidth="2" />
+        <circle id="traveller-slow" cx="280" cy="200" r="5" fill="#666" />
+      </g>
+      <g id="core">
+        <circle cx="200" cy="200" r="30" fill="#222" opacity="0.85" />
+        <circle cx="200" cy="200" r="45" fill="none" stroke="#326FB7" strokeWidth="2" opacity="0.9" />
+      </g>
+    </svg>
+  );
+}

--- a/src/components/LivingMatrix.jsx
+++ b/src/components/LivingMatrix.jsx
@@ -1,35 +1,39 @@
 import React from "https://esm.sh/react@18";
 
 export default function LivingMatrix({ d = 1, mu = 1, s = 1, tau = 1, k = 1 }) {
-  const style = {
-    '--d': d,
-    '--mu': mu,
-    '--s': s,
-    '--tau': tau,
-    '--k': k,
-  };
-  return (
-    <svg viewBox="0 0 400 400" className="matrix-svg" style={style}>
-      <rect width="400" height="400" fill="#f8fafc" />
-      <g id="outer-field">
-        <circle cx="200" cy="200" r="180" fill="none" stroke="#326FB7" strokeWidth="2" opacity="0.8" />
-      </g>
-      <g id="petals" opacity="0.6">
-        <circle cx="200" cy="200" r="120" fill="none" stroke="#aeb4b9" strokeWidth="1.5" />
-        <circle cx="200" cy="200" r="100" fill="none" stroke="#aeb4b9" strokeWidth="1.5" />
-      </g>
-      <g id="orbit-fast">
-        <ellipse cx="200" cy="200" rx="160" ry="100" fill="none" stroke="#111" strokeWidth="2.5" />
-        <circle id="traveller-fast" cx="360" cy="200" r="6" fill="#111" />
-      </g>
-      <g id="orbit-slow">
-        <ellipse cx="200" cy="200" rx="80" ry="140" fill="none" stroke="#666" strokeWidth="2" />
-        <circle id="traveller-slow" cx="280" cy="200" r="5" fill="#666" />
-      </g>
-      <g id="core">
-        <circle cx="200" cy="200" r="30" fill="#222" opacity="0.85" />
-        <circle cx="200" cy="200" r="45" fill="none" stroke="#326FB7" strokeWidth="2" opacity="0.9" />
-      </g>
-    </svg>
+  const style = { '--d': d, '--mu': mu, '--s': s, '--tau': tau, '--k': k };
+  return React.createElement(
+    "svg",
+    { viewBox: "0 0 400 400", className: "matrix-svg", style },
+    React.createElement("rect", { width: 400, height: 400, fill: "#f8fafc" }),
+    React.createElement(
+      "g",
+      { id: "outer-field" },
+      React.createElement("circle", { cx: 200, cy: 200, r: 180, fill: "none", stroke: "#326FB7", strokeWidth: 2, opacity: 0.8 })
+    ),
+    React.createElement(
+      "g",
+      { id: "petals", opacity: 0.6 },
+      React.createElement("circle", { cx: 200, cy: 200, r: 120, fill: "none", stroke: "#aeb4b9", strokeWidth: 1.5 }),
+      React.createElement("circle", { cx: 200, cy: 200, r: 100, fill: "none", stroke: "#aeb4b9", strokeWidth: 1.5 })
+    ),
+    React.createElement(
+      "g",
+      { id: "orbit-fast" },
+      React.createElement("ellipse", { cx: 200, cy: 200, rx: 160, ry: 100, fill: "none", stroke: "#111", strokeWidth: 2.5 }),
+      React.createElement("circle", { id: "traveller-fast", cx: 360, cy: 200, r: 6, fill: "#111" })
+    ),
+    React.createElement(
+      "g",
+      { id: "orbit-slow" },
+      React.createElement("ellipse", { cx: 200, cy: 200, rx: 80, ry: 140, fill: "none", stroke: "#666", strokeWidth: 2 }),
+      React.createElement("circle", { id: "traveller-slow", cx: 280, cy: 200, r: 5, fill: "#666" })
+    ),
+    React.createElement(
+      "g",
+      { id: "core" },
+      React.createElement("circle", { cx: 200, cy: 200, r: 30, fill: "#222", opacity: 0.85 }),
+      React.createElement("circle", { cx: 200, cy: 200, r: 45, fill: "none", stroke: "#326FB7", strokeWidth: 2, opacity: 0.9 })
+    )
   );
 }


### PR DESCRIPTION
## Summary
- enable importing PDF itineraries in the Trips tab using PDF.js
- render parsed PDF text into a preview table with optional saving to localStorage
- remember saved trips and show them on subsequent visits

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b727bebed8832194b7202881fb4a86